### PR TITLE
fix(astro): pass resolved config to component generator so template classes apply

### DIFF
--- a/libs/astro/src/load-salty-file.ts
+++ b/libs/astro/src/load-salty-file.ts
@@ -44,6 +44,13 @@ export const loadSaltyFile = async (ctx: AstroPluginContext, filePath: string): 
 
       const compiled = await saltyCompiler.compileSaltyFile(filePath, destDir);
 
+      // The resolved config (templates, variables, modifiers, …) is required by
+      // the generator: `getTemplateClasses()` reads `config.templates` to compose
+      // template utility classes (e.g. `textStyle`) onto the component, and bails
+      // out returning `[]` when it is missing. Passing `{}` here silently dropped
+      // those classes from every Astro component. Mirrors SaltyCompiler.generateFile.
+      const config = await saltyCompiler.getConfig();
+
       const components = Object.entries(compiled.contents);
       for (const [name, value] of components) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -54,7 +61,7 @@ export const loadSaltyFile = async (ctx: AstroPluginContext, filePath: string): 
           const generator = resolved.generator._withBuildContext({
             callerName: name,
             isProduction: saltyCompiler.isProduction,
-            config: {},
+            config,
           });
 
           consts.push(`const ${name} = classNameInstance(${JSON.stringify(generator.params)});`);
@@ -73,7 +80,7 @@ export const loadSaltyFile = async (ctx: AstroPluginContext, filePath: string): 
         const generator = resolved.generator._withBuildContext({
           callerName: name,
           isProduction: saltyCompiler.isProduction,
-          config: {},
+          config,
         });
 
         const fileConfig = {


### PR DESCRIPTION
## Problem

In Astro, `defineTemplates` tokens used inside a `styled()` / `className()` `base` (e.g. `textStyle: 'body.large'`) are silently dropped — the element never receives the template's utility class, so the styles never apply.

The `.text-style-*` classes **are** generated correctly into `saltygen/css/_templates.css` (with their `.t_<hash>` aliases). They just never get composed onto any component, so visually nothing happens.

## Root cause

`libs/astro/src/load-salty-file.ts` builds each component's generator context with an **empty config**:

```ts
const generator = resolved.generator._withBuildContext({
  callerName: name,
  isProduction: saltyCompiler.isProduction,
  config: {},   // ← here, in both the className and styled branches
});
```

The generator's `classNames` getter calls `getTemplateClasses()`, which begins:

```ts
getTemplateClasses(config = this.buildContext.config) {
  if (!config?.templates || !this.params.base || this.priority > 0) return [];
  ...
}
```

With `config = {}` there is no `config.templates`, so it returns `[]` and no `t_…` / `text-style-*` classes are added to the component's `classNames`. The per-component `.config` files end up with only the component's own hash.

By contrast, the core `SaltyCompiler.generateFile` builds its generator context with the real config (`const config = await this.getConfig(); … _withBuildContext({ …, config })`), which is why CSS generation sees templates but the Astro `.config`/`classNames` generation does not.

## Fix

Fetch the resolved config once via `saltyCompiler.getConfig()` and pass it to both `_withBuildContext` call sites — mirroring `SaltyCompiler.generateFile`.

## Verification

Tested by applying the equivalent change to the built `@salty-css/astro@0.4.2` output in a real Astro SSR project (`output: 'server'`, Cloudflare adapter) that uses a `textStyle` template:

- **Before:** component config `"classNames":"jRfSO"` — template styles missing.
- **After:** `"classNames":"jRfSO t_tTvl t_qNBH"` — `body` base + `body.small` leaf composed onto the element; 29 components across the site picked up their template classes.
- Full `astro build` completes successfully (exit 0).

No API or behavior change beyond templates now resolving for Astro as they already do via the core compiler.