### PR TITLE
fix(core): support media queries and nested selectors inside templates

### DIFF
--- a/libs/core/src/compiler/salty-compiler.ts
+++ b/libs/core/src/compiler/salty-compiler.ts
@@ -588,7 +588,7 @@ export class SaltyCompiler {
     const templateStylesPath = join(destDir, 'css/_templates.css');
     const templates = mergeObjects<CssTemplates>(config.templates, generationResults.templates);
 
-    const templateStylesString = await parseTemplates(templates);
+    const templateStylesString = await parseTemplates(templates, [], config);
     const templateTokens = getTemplateTypes(templates);
     const templateVariantMaps = getTemplateVariantMaps(templates as Record<string, any>);
 

--- a/libs/core/src/parsers/parse-templates.spec.ts
+++ b/libs/core/src/parsers/parse-templates.spec.ts
@@ -68,3 +68,58 @@ describe('parseTemplates - rich variant emission', () => {
     expect(css).toContain('.text-style-body-regular');
   });
 });
+
+describe('parseTemplates - media queries', () => {
+  it('wraps a media query declared inside a leaf and keeps it on the leaf class', async () => {
+    const css = await parseTemplates({
+      textStyle: {
+        body: {
+          large: {
+            fontSize: '28px',
+            '@media (max-width: 960px)': { fontSize: '20px' },
+          },
+        },
+      },
+    });
+    expect(compact(css)).toContain('@media(max-width:960px)');
+    expect(compact(css)).toContain('font-size:20px');
+    // The media-query key must not leak into the class name (the bug produced
+    // `.text-style-body-large-@media-max-width-960px` with no `@media` wrapper).
+    expect(css).not.toMatch(/text-style-body-large-/);
+  });
+
+  it('resolves a named media query inside a template via the forwarded config', async () => {
+    const css = await parseTemplates(
+      {
+        textStyle: {
+          body: {
+            large: {
+              fontSize: '28px',
+              '@largeMobileDown': { fontSize: '20px' },
+            },
+          },
+        },
+      },
+      [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { mediaQueries: { '@largeMobileDown': '@media (max-width: 960px)' } } as any,
+    );
+    expect(compact(css)).toContain('@media(max-width:960px)');
+    expect(css).not.toContain('@largeMobileDown');
+  });
+
+  it('wraps a media query declared in a rich node base', async () => {
+    const css = await parseTemplates({
+      textStyle: {
+        headline: {
+          base: {
+            color: 'red',
+            '@media (max-width: 960px)': { color: 'blue' },
+          },
+        },
+      },
+    });
+    expect(compact(css)).toContain('@media(max-width:960px)');
+    expect(compact(css)).toContain('color:blue');
+  });
+});

--- a/libs/core/src/parsers/parse-templates.ts
+++ b/libs/core/src/parsers/parse-templates.ts
@@ -6,21 +6,45 @@ import { isRichTemplateNode } from './resolve-template-variants';
 
 const RICH_META_KEYS = new Set(['base', 'variants', 'defaultVariants', 'compoundVariants', 'anyOfVariants']);
 
+/**
+ * A CSS construct key — an at-rule (`@media`, `@container`, …), a nested selector
+ * (`&:hover`, `& .child`) or a pseudo (`:hover`). These describe styles for the
+ * *current* node and must be handed to the style parser, never dash-cased into a
+ * class name or recursed into as if they were a nested template path. Without this
+ * guard `{ large: { '@largeMobileDown': { … } } }` compiled to a flat class
+ * `.…-large-@large-mobile-down` with no `@media` wrapper (and was never applied).
+ */
+const isStyleKey = (key: string): boolean => /^[@&:]/.test(key.trim());
+
 const isChildEntry = (key: string, value: unknown): boolean => {
   if (RICH_META_KEYS.has(key)) return false;
+  if (isStyleKey(key)) return false;
   return !!value && typeof value === 'object' && !Array.isArray(value);
 };
 
-export const parseTemplates = async <T extends object>(obj: T, path: PropertyKey[] = []): Promise<string> => {
+// The config is forwarded to the style parser so template styles resolve named
+// media queries, modifiers and tokens exactly like component styles do. Template
+// definitions are literal styles, so template-token expansion is disabled
+// (`omitTemplates`) to avoid a template recursively expanding another template.
+type TemplateParseConfig = Parameters<typeof parseAndJoinStyles>[2];
+
+export const parseTemplates = async <T extends object>(obj: T, path: PropertyKey[] = [], config?: TemplateParseConfig): Promise<string> => {
   if (!obj) return '';
   const classes: string[] = [];
 
   if (isRichTemplateNode(obj)) {
     const rich = obj as RichTemplateNode;
     const baseClassName = path.map((p) => dashCase(String(p))).join('-');
-    if (rich.base) {
+
+    // `base` plus any node-level CSS constructs (e.g. a `@media` declared
+    // directly on the node) render together under this node's class.
+    const ownStyles: Record<string, any> = { ...(rich.base as Record<string, any> | undefined) };
+    for (const [key, value] of Object.entries(rich)) {
+      if (isStyleKey(key)) ownStyles[key] = value;
+    }
+    if (Object.keys(ownStyles).length) {
       const hashClass = 't_' + toHash(baseClassName, 4);
-      const result = await parseAndJoinStyles(rich.base as Record<string, any>, `.${baseClassName}, .${hashClass}`);
+      const result = await parseAndJoinStyles(ownStyles, `.${baseClassName}, .${hashClass}`, config, true);
       classes.push(result);
     }
     if (rich.variants) {
@@ -30,14 +54,14 @@ export const parseTemplates = async <T extends object>(obj: T, path: PropertyKey
           if (!styles || typeof styles !== 'object') continue;
           const variantClassName = `${baseClassName}-${dashCase(axis)}-${dashCase(value)}`;
           const variantHashClass = 'tv_' + toHash(variantClassName, 4);
-          const result = await parseAndJoinStyles(styles as Record<string, any>, `.${variantClassName}, .${variantHashClass}`);
+          const result = await parseAndJoinStyles(styles as Record<string, any>, `.${variantClassName}, .${variantHashClass}`, config, true);
           classes.push(result);
         }
       }
     }
     for (const [key, value] of Object.entries(rich)) {
       if (!isChildEntry(key, value)) continue;
-      const result = await parseTemplates(value as object, [...path, key.trim()]);
+      const result = await parseTemplates(value as object, [...path, key.trim()], config);
       classes.push(result);
     }
     return classes.join('\n');
@@ -48,11 +72,14 @@ export const parseTemplates = async <T extends object>(obj: T, path: PropertyKey
   for (const [key, value] of Object.entries(obj)) {
     if (typeof value === 'function') {
       // Skip functions
-    } else if (value && typeof value === 'object') {
+    } else if (value && typeof value === 'object' && !isStyleKey(key)) {
+      // A nested template sub-path (e.g. `large`, `medium`).
       const _key = key.trim();
-      const result = await parseTemplates(value, [...path, _key]);
+      const result = await parseTemplates(value, [...path, _key], config);
       classes.push(result);
     } else {
+      // A scalar declaration, or a CSS construct (`@media`, `&…`, `:…`) whose
+      // object body is real CSS for this level — both go to the style parser.
       levelStyles[key] = value;
     }
   }
@@ -60,7 +87,7 @@ export const parseTemplates = async <T extends object>(obj: T, path: PropertyKey
   if (Object.keys(levelStyles).length) {
     const className = path.map((p) => dashCase(String(p))).join('-');
     const hashClass = 't_' + toHash(className, 4);
-    const result = await parseAndJoinStyles(levelStyles, `.${className}, .${hashClass}`);
+    const result = await parseAndJoinStyles(levelStyles, `.${className}, .${hashClass}`, config, true);
     classes.push(result);
   }
 
@@ -103,7 +130,7 @@ export const getTemplateTokens = <T extends object>(templates: T, parent = '', t
 
   Object.entries(templates).forEach(([key, value]) => {
     const keyValue = parent ? `${parent}.${key}` : key;
-    if (value && typeof value === 'object') return getTemplateTokens(value, keyValue, templateTokens);
+    if (value && typeof value === 'object' && !isStyleKey(key)) return getTemplateTokens(value, keyValue, templateTokens);
     return templateTokens.add(parent);
   });
 
@@ -165,7 +192,7 @@ const walk = (node: any, path: string[], out: Record<string, Record<string, stri
     return;
   }
   for (const [key, value] of Object.entries(node as Record<string, any>)) {
-    if (!value || typeof value !== 'object' || Array.isArray(value)) continue;
+    if (!value || typeof value !== 'object' || Array.isArray(value) || isStyleKey(key)) continue;
     walk(value, [...path, key.trim()], out, axes);
   }
 };


### PR DESCRIPTION
## Problem

Media queries (and nested selectors / pseudos) declared inside a `defineTemplates` node never work. Given:

```ts
defineTemplates({
  textStyle: {
    heading: {
      large: {
        fontSize: '110px',
        '@largeMobileDown': { fontSize: '60px' },
      },
    },
  },
});
```

the generated `_templates.css` contains:

```css
.text-style-heading-large-@large-mobile-down, .t_wIUD { font-size: 60px; }
```

— no `@media` wrapper, and the bogus class is never composed onto any element, so the responsive override is silently dead.

## Root cause

`parseTemplates` (`libs/core/src/parsers/parse-templates.ts`) re-implements template→CSS rendering and diverges from the normal style parser in two ways:

1. **It treats every object-valued key as a nested template path segment.** A media query like `'@largeMobileDown': { … }` is an object, so it gets recursed as a path and dash-cased into the class name, with no `@media` wrapping. `getTemplateClasses()` only walks the declared path (`heading.large`), so that class is never applied either.
2. **It never forwards the config to `parseAndJoinStyles`.** So even when a query lives in a rich node's `base` (where the object *is* passed to the parser), the *named* query isn't resolved — it's emitted as a literal `@largeMobileDown { … }` instead of `@media (max-width: 960px)`.

By contrast, normal component styles go through `parseStyles` with the config, which handles `@media`/named queries/modifiers correctly.

## Fix

- Add `isStyleKey` — keys starting with `@`, `&` or `:` are CSS constructs for the current node, not template paths. Route them to the style parser instead of recursing:
  - in non-rich **leaves** (collected into the rendered style object),
  - in **rich** nodes (node-level constructs render with `base`),
  - and in `isChildEntry` / the token & variant-map walkers, so they no longer leak into generated template token types.
- Forward the resolved config from `SaltyCompiler.generateCss` through `parseTemplates` into `parseAndJoinStyles`, with `omitTemplates` enabled (template definitions are literal styles and shouldn't recursively expand other templates). Named media queries, modifiers and tokens now resolve in templates exactly as in component styles.

## Tests

Added three cases to `parse-templates.spec.ts`:
- media query in a leaf → wrapped in `@media`, kept on the leaf class, not leaked into the class name;
- named media query → resolved via the forwarded config;
- media query in a rich node `base` → wrapped correctly.

`nx run core:test` (vitest, `libs/core/src`): **23 files / 449 tests pass** (4 existing template tests + 3 new). Typecheck of `libs/core` is clean.

No behavior change for templates without `@`/`&`/`:` keys.